### PR TITLE
Docker Machine + Virtual Machine + NFS + Choose PHP Version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/src/*
+.DS_Store
+/.idea
+/*.log

--- a/magento1/init
+++ b/magento1/init
@@ -16,8 +16,10 @@ fi
 
 if [ "$3" ]; then
   sed -i '' -e "s/<php_version>/$3/g" Dockerfile;
+  sed -i '' -e "s/<php_version>/$3/g" docker-compose.yml;
 else
   sed -i '' -e "s/<php_version>/5.5/g" Dockerfile;
+  sed -i '' -e "s/<php_version>/master/g" docker-compose.yml;
 fi
 
 if [ ! -e src/index.php ]; then

--- a/magento1/init
+++ b/magento1/init
@@ -14,6 +14,12 @@ else
   sed -i '' -e "s/<project_name>/$1/g" docker-compose.yml;
 fi
 
+if [ "$3" ]; then
+  sed -i '' -e "s/<php_version>/$3/g" Dockerfile;
+else
+  sed -i '' -e "s/<php_version>/5.5/g" Dockerfile;
+fi
+
 if [ ! -e src/index.php ]; then
   echo "<?php phpinfo();" > src/index.php;
 fi

--- a/magento1/init
+++ b/magento1/init
@@ -5,7 +5,7 @@ fi
 
 sudo chmod u+x ./*
 
-if [ "$(uname)" == "Darwin" ] || [ "$(uname)" == "cygwin" ] || [ "$(uname)" == "msys" ] || [ "$(uname)" == "win32" ]; then
+if [ "$(uname)" == "cygwin" ] || [ "$(uname)" == "msys" ] || [ "$(uname)" == "win32" ]; then
   git checkout -f mac;
   sed -i '' -e "s/<project_name>/$1/g" docker-compose.yml \
   && sed -i '' -e "s/<project_name>/$1/g" docker-sync.yml

--- a/magento1/init
+++ b/magento1/init
@@ -5,6 +5,12 @@ fi
 
 sudo chmod u+x ./*
 
+if [ "$3" ]; then
+  docker image pull viniciusbord9/magento1:$3
+else
+  docker image pull viniciusbord9/magento1
+fi
+
 if [ "$(uname)" == "cygwin" ] || [ "$(uname)" == "msys" ] || [ "$(uname)" == "win32" ]; then
   git checkout -f mac;
   sed -i '' -e "s/<project_name>/$1/g" docker-compose.yml \
@@ -19,7 +25,7 @@ if [ "$3" ]; then
   sed -i '' -e "s/<php_version>/$3/g" docker-compose.yml;
 else
   sed -i '' -e "s/<php_version>/5.5/g" Dockerfile;
-  sed -i '' -e "s/<php_version>/master/g" docker-compose.yml;
+  sed -i '' -e "s/<php_version>/latest/g" docker-compose.yml;
 fi
 
 if [ ! -e src/index.php ]; then

--- a/magento2/init
+++ b/magento2/init
@@ -13,15 +13,7 @@ sudo chmod -R u+x ./*
 docker image pull viniciusbord9/magento2
 docker image pull viniciusbord9/magento2:varnish
 
-if [ "$(uname)" == "Darwin" ]; then
-    git checkout -f mac;
-    sed -i '' -e "s/<project_name>/$1/g" docker-compose.yml \
-    && sed -i '' -e "s/<project_name>/$1/g" docker-compose-dev.yml \
-    && sed -i '' -e "s/<project_name>/$1/g" docker-compose.elasticsearch.yml \
-    && sed -i '' -e "s/<project_name>/$1/g" docker-compose.loadbalancer.yml \
-    && sed -i '' -e "s/<project_name>/$1/g" docker-compose.varnish.yml \
-    && sed -i '' -e "s/<project_name>/$1/g" docker-sync.yml;
-elif [ "$(uname)" == "cygwin" ] || [ "$(uname)" == "msys" ] || [ "$(uname)" == "win32" ]; then
+if [ "$(uname)" == "cygwin" ] || [ "$(uname)" == "msys" ] || [ "$(uname)" == "win32" ]; then
     git checkout -f windows;
     sed -i '' -e "s/<project_name>/$1/g" docker-compose.yml \
     && sed -i '' -e "s/<project_name>/$1/g" docker-compose-dev.yml \

--- a/magento2/init
+++ b/magento2/init
@@ -29,6 +29,12 @@ else
     sed -i '' -e "s/<project_name>/$1/g" docker-compose.varnish.yml;
 fi
 
+if [ "$3" ]; then
+  sed -i '' -e "s/<php_version>/$3/g" Dockerfile;
+else
+  sed -i '' -e "s/<php_version>/7.0/g" Dockerfile;
+fi
+
 if [ ! -e src/index.php ]; then
   echo "<?php phpinfo();" > src/index.php;
 fi

--- a/magento2/init
+++ b/magento2/init
@@ -39,7 +39,7 @@ if [ "$3" ]; then
   sed -i '' -e "s/<php_version>/$3/g" docker-compose.yml;
 else
   sed -i '' -e "s/<php_version>/7.0/g" Dockerfile;
-  sed -i '' -e "s/<php_version>/master/g" docker-compose.yml;
+  sed -i '' -e "s/<php_version>/latest/g" docker-compose.yml;
 fi
 
 if [ ! -e src/index.php ]; then

--- a/magento2/init
+++ b/magento2/init
@@ -31,8 +31,10 @@ fi
 
 if [ "$3" ]; then
   sed -i '' -e "s/<php_version>/$3/g" Dockerfile;
+  sed -i '' -e "s/<php_version>/$3/g" docker-compose.yml;
 else
   sed -i '' -e "s/<php_version>/7.0/g" Dockerfile;
+  sed -i '' -e "s/<php_version>/master/g" docker-compose.yml;
 fi
 
 if [ ! -e src/index.php ]; then

--- a/magento2/init
+++ b/magento2/init
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 if [ "$2" == "clone" ]; then
-  git clone https://github.com/redstage/docker-linux-m2.git $1 && cd $1;
+  git clone https://github.com/acarvalho-redstage/docker-linux-m2.git $1 && cd $1;
 fi
 
 git config --global core.autocrlf false
@@ -10,7 +10,12 @@ git config --global diff.renamelimit 5000
 
 sudo chmod -R u+x ./*
 
-docker image pull viniciusbord9/magento2
+if [ "$3" ]; then
+  docker image pull viniciusbord9/magento2:$3
+else
+  docker image pull viniciusbord9/magento2
+fi
+
 docker image pull viniciusbord9/magento2:varnish
 
 if [ "$(uname)" == "cygwin" ] || [ "$(uname)" == "msys" ] || [ "$(uname)" == "win32" ]; then

--- a/magento2/init
+++ b/magento2/init
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 if [ "$2" == "clone" ]; then
-  git clone https://github.com/acarvalho-redstage/docker-linux-m2.git $1 && cd $1;
+  git clone https://github.com/redstage/docker-linux-m2.git $1 && cd $1;
 fi
 
 git config --global core.autocrlf false


### PR DESCRIPTION
Docker for MacOS
--
We don't need these conditionals anymore, because I created a new way to use Docker on MacOS without docker-sync or other convencional synchronise between host and guest. In this case we will use a VM + docker-machine + NFS.

@viniciusbordinhao-redstage, if you want to see how it is work, please read the document for this tool below.

Shared Document
--
[Click here](https://rsn-my.sharepoint.com/:b:/g/personal/acarvalho_redstage_com/EbZTDMkPd19CgVTuR0gkDHYBA_JtQWr9-AhvF3M1N7GbPg?e=aDEqwN)

PHP Version for M1
--
Default: 5.5

### The PHP version will be 5.5 - Standard
curl -s https://raw.githubusercontent.com/redstage/docker-linux-init/master/magento1/init | bash -s MYMAGENTO clone

### The PHP version will be 5.6
curl -s https://raw.githubusercontent.com/redstage/docker-linux-init/master/magento1/init | bash -s MYMAGENTO clone **5.6**

PHP Version for M2
--
Default: 7.0

### The PHP version will be 7.0 - Standard
curl -s https://raw.githubusercontent.com/redstage/docker-linux-init/master/magento2/init | bash -s MYMAGENTO clone

### The PHP version will be 7.1
curl -s https://raw.githubusercontent.com/redstage/docker-linux-init/master/magento2/init | bash -s MYMAGENTO clone **7.1**

I made de improvement because I need to upgrade my PHP version from 7.0 to 7.1 to run Apria on my local.